### PR TITLE
chore: add `process-functions` input

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -67,6 +67,10 @@ inputs:
     required: false
     description: "Skip all Atmos functions such as terraform.output in `atmos describe affected`"
     default: "false"
+  process-functions:
+    required: false
+    description: "Whether to process atmos functions"
+    default: "true"
   process-templates:
     required: false
     description: "Skip all Atmos functions such as terraform.output in `atmos describe affected`"
@@ -99,6 +103,7 @@ runs:
         jq-version: ${{inputs.jq-version}}
         jq-force: ${{inputs.jq-force}}
         skip-atmos-functions: ${{inputs.skip-atmos-functions}}
+        process-functions: ${{inputs.process-functions}}
         process-templates: ${{inputs.process-templates}}
 
     - name: Setup Spacectl


### PR DESCRIPTION
## what
- add `process-functions` flag

## why
- we are using `!terraform.state` functions now and atmos cannot execute `atmos describe affected` because the runners to have access to read state files
- we do not need the actual values populated, this action just detects what stacks have changed and triggers their Spacelift preview runs
- upgrade atmos to match infrastructure version

## references
- https://github.com/BrightDotAi/infrastructure/pull/2932
